### PR TITLE
Add a CONTRIBUTING.md guideline for issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Creating Issues
+**Please include:**
++ [ ] Output from `git show`.
+  + Please wrap it in three backticks (\`\`\`)
+  + We only need the commit that you are using. Please make sure you are on the latest version.
++ [ ] A detailed explanation of the bug.
+  + [ ] What is the expected behavior?
+  + [ ] What do you see instead?
++ [ ] If applicable, the steps to reproduce the bug.
+
+This information makes it much easier to fix issues.
+
+# Creating PRs
+If you're making PRs, you likely know what to include already.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,12 @@
 + [ ] Output from `git show`.
   + Please wrap it in three backticks (\`\`\`)
   + We only need the commit that you are using. Please make sure you are on the latest version.
++ [ ] Output from `journalctl /usr/bin/gnome-shell`
+  + Please include as much output as possible. If necessary, create a Gist and link to it.
 + [ ] A detailed explanation of the bug.
   + [ ] What is the expected behavior?
   + [ ] What do you see instead?
+  + [ ] Screenshots (if it is a graphical bug)
 + [ ] If applicable, the steps to reproduce the bug.
 
 This information makes it much easier to fix issues.


### PR DESCRIPTION
Some issues that have been created are quite lacking in information. These guidelines should help people include enough info to get the bugs quickly fixed.