### PR TITLE
AUR link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ git clone https://github.com/PapyElGringo/material-shell.git ~/.local/share/gnom
 2) Reload gnome-shell by hitting `Alt+F2` and typing the command `r`
 3) Open `gnome-tweaks` and activate `Material-shell` extension
 
+#### Arch Linux (AUR):
+[Henri98 created a package for material-shell on the AUR.](https://aur.archlinux.org/packages/gnome-shell-extension-material-shell-git/)
+```
+yay gnome-shell-extension-material-shell-git
+```
+
 ## Workflow Hotkeys
 Some hotkeys might already be used by gnome shell, please check your keybindings first
 #### Desktop navigation


### PR DESCRIPTION
Adds both the link to the AUR package, as well as a copy&paste command for the most popular AUR helper. At the time of writing 62,48 popularity compared to pikaur 9,16 popularity.

Could change it to a direct link to the package and omitting the copy&paste command, as suggested by "ignormies", because the most popular AUR helper changes frequently. But can also just make a new pull request in that case.