### PR TITLE
Revamp README and add instructions for compiling Sass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,22 @@ This information makes it much easier to fix issues.
 
 # Creating PRs
 If you're making PRs, you likely know what to include already.
+
+You also may benefit from some instructions on compiling the Sass stylesheet:
+
+## Modifying the Stylesheet
+The stylesheet is written in [Sass](https://sass-lang.com) so it must be compiled before reloading it.
+First, make sure to install the Sass command line tool with `npm`:
+```bash
+npm install -g sass
+```
+If Sass is installed, then:
+1) Make changes to the `stylesheet.scss` file as you please.
+2) Compile the file, and generate a sourcemap:
+```bash
+cd ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
+sass stylesheet.scss:stylesheet.css --sourcemap
+```
+3) Reload GNOME Shell:
+  + On X.org: hit `Alt+F2` and type the command `r`
+  + On Wayland: Log out and back in

--- a/README.md
+++ b/README.md
@@ -18,26 +18,13 @@ Get notified about updates and join me at [https://discord.gg/vBb7D9a](https://d
 ```bash
 git clone https://github.com/PapyElGringo/material-shell.git ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
 ```
-2) Reload GNOME Shell by hitting `Alt+F2` and typing the command `r`
-3) Open `gnome-tweaks` and activate `Material-shell` extension **OR** enable it using 
+2) Reload GNOME Shell:
+  + On X.org: Hit `Alt+F2` and type the command `r`
+  + On Wayland: Log out and back in
+3) Open `gnome-tweaks` and activate the `Material-shell` extension **OR** enable it using 
 ```bash
 gnome-shell-extension-tool -e material-shell@papyelgringo
 ```
-
-## Modifying the Stylesheet
-The stylesheet is written in [Sass](https://sass-lang.com) so it must be compiled before it can be reloaded.
-First, make sure to install the Sass command line tool with `npm`:
-```bash
-npm install -g sass
-```
-If Sass is installed, then:
-1) Make changes to the `stylesheet.scss` file as you please.
-2) Compile the file, and generate a sourcemap:
-```bash
-cd ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
-sass stylesheet.scss:stylesheet.css --sourcemap
-```
-3) Reload GNOME Shell by hitting `Alt+F2` and typing the command `r`
 
 ### Arch Linux
 1) You can choose to install using the Arch Linux User-Community Repository (AUR) https://aur.archlinux.org/packages/gnome-shell-extension-material-shell-git/ \
@@ -45,9 +32,13 @@ Assuming you're using yay:
 ```
 yay -S gnome-shell-extension-material-shell-git
 ```
-2) Reload gnome-shell by hitting `Alt+F2` and typing the command `r`
-3) Open `gnome-tweaks` and activate `Material-shell` extension
-
+2) Reload GNOME Shell:
+  + On X.org: Hit `Alt+F2` and type the command `r`
+  + On Wayland: Log out and back in
+3) Open `gnome-tweaks` and activate the `Material-shell` extension **OR** enable it using 
+```bash
+gnome-shell-extension-tool -e material-shell@papyelgringo
+```
 
 ## Workflow Hotkeys
 Some hotkeys might already be used by GNOME Shell - please check your keybindings first.
@@ -61,7 +52,7 @@ Some hotkeys might already be used by GNOME Shell - please check your keybinding
 * `Super+Q` Kill the current window focused.
 * `Super+[MouseDrag]` Move window around.
 
-#
+
 ## Optional Configuration
 * Get [Plata Theme](https://gitlab.com/tista500/plata-theme) as the GTK and shell theme 
 * Get [Tela Icon Theme](https://github.com/vinceliuice/Tela-icon-theme) as the icon theme

--- a/README.md
+++ b/README.md
@@ -1,27 +1,46 @@
-## Material Tiling shell replacement for Gnome-shell to simplify and accelerate daily workflow and productivity.
+# Material Shell
+## A material tiling shell replacement for GNOME Shell to simplify your workflow and accelerate your productivity.
 
-Following my earlier work on [Material Awesome](https://github.com/PapyElGringo/material-awesome). This gnome-shell extension provide a performant opinionated mouse/keyboard workflow and follow the [Material Design guidelines](https://material.io)
+The project is based on my earlier work on [Material Awesome](https://github.com/PapyElGringo/material-awesome). This GNOME Shell extension provides a performant, opinionated mouse/keyboard workflow and follows the [Material Design guidelines](https://material.io).
 
 ## Demo
 
-![](demo.gif)
+![Demo GIF](demo.gif)
 
 ### Discord
-Get notified on updates and join me at [https://discord.gg/vBb7D9a](https://discord.gg/vBb7D9a)
+Get notified about updates and join me at [https://discord.gg/vBb7D9a](https://discord.gg/vBb7D9a)
 #
-#### STATUS: BETA
-#### REQUIRE: Gnome-shell 3.32.x
+#### STATUS: BETA (expect bugs!)
+#### REQUIRES: gnome-shell >=3.32.0
 
 ## Installation
-1) Clone the project to the gnome-shell extensions folders
-```
+1) Clone the project to the gnome-shell extensions folder:
+```bash
 git clone https://github.com/PapyElGringo/material-shell.git ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
 ```
-2) Reload gnome-shell by hitting `Alt+F2` and typing the command `r`
-3) Open `gnome-tweaks` and activate `Material-shell` extension
+2) Reload GNOME shell by hitting `Alt+F2` and typing the command `r`
+3) Open `gnome-tweaks` and activate `Material-shell` extension **OR** enable it using 
+```bash
+gnome-shell-extension-tool -e material-shell@papyelgringo
+```
+
+## Modifying the Stylesheet
+The stylesheet is written in [Sass](https://sass-lang.com) so it must be compiled before reloading it.
+First, make sure to install the Sass command line tool with `npm`:
+```bash
+npm install -g sass
+```
+If Sass is installed, then:
+1) Make changes to the `stylesheet.scss` file as you please.
+2) Compile the file, and generate a sourcemap:
+```bash
+cd ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
+sass stylesheet.scss:stylesheet.css --sourcemap
+```
+3) Reload GNOME Shell by hitting `Alt+F2` and typing the command `r`
 
 ## Workflow Hotkeys
-Some hotkeys might already be used by gnome shell, please check your keybindings first
+Some hotkeys might already be used by GNOME Shell - please check your keybindings first.
 #### Desktop navigation
 * `Super+W` Navigate to the upper workspace/category.
 * `Super+S` Navigate to the lower workspace/category.
@@ -33,6 +52,6 @@ Some hotkeys might already be used by gnome shell, please check your keybindings
 * `Super+[MouseDrag]` Move window around.
 
 #
-## Recommendations
-* Get [plata-theme](https://gitlab.com/tista500/plata-theme) GTK and Shell theme 
-* Get [Tela-icon-theme](https://github.com/vinceliuice/Tela-icon-theme) Icon theme
+## Optional Configuration
+* Get [Plata Theme](https://gitlab.com/tista500/plata-theme) as the GTK and shell theme 
+* Get [Tela Icon Theme](https://github.com/vinceliuice/Tela-icon-theme) as the icon theme

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Get notified about updates and join me at [https://discord.gg/vBb7D9a](https://d
 ```bash
 git clone https://github.com/PapyElGringo/material-shell.git ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
 ```
-2) Reload GNOME shell by hitting `Alt+F2` and typing the command `r`
+2) Reload GNOME Shell by hitting `Alt+F2` and typing the command `r`
 3) Open `gnome-tweaks` and activate `Material-shell` extension **OR** enable it using 
 ```bash
 gnome-shell-extension-tool -e material-shell@papyelgringo
 ```
 
 ## Modifying the Stylesheet
-The stylesheet is written in [Sass](https://sass-lang.com) so it must be compiled before reloading it.
+The stylesheet is written in [Sass](https://sass-lang.com) so it must be compiled before it can be reloaded.
 First, make sure to install the Sass command line tool with `npm`:
 ```bash
 npm install -g sass


### PR DESCRIPTION
Just a few edits to improve consistency within the README. I also figured that people who would be editing the Sass might want instructions on compiling it.