### PR TITLE
Exports should be vars and not const

### DIFF
--- a/tilingManager/tilingLayouts/layouts.js
+++ b/tilingManager/tilingLayouts/layouts.js
@@ -26,7 +26,7 @@ const layouts = [
 ];
 
 /* exported TilingLayoutByKey */
-const TilingLayoutByKey = layouts.reduce((layoutsByKey, layout) => {
+var TilingLayoutByKey = layouts.reduce((layoutsByKey, layout) => {
     layoutsByKey[layout.key] = layout;
     return layoutsByKey;
 }, {});


### PR DESCRIPTION
This prevents this warning:
```
Some code accessed the property 'TilingLayoutByKey' on the module 'layouts'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
```