### PR TITLE
Improve wayland support

### DIFF
--- a/tilingManager/tilingLayouts/baseTiling.js
+++ b/tilingManager/tilingLayouts/baseTiling.js
@@ -237,7 +237,8 @@ var BaseTilingLayout = class BaseTilingLayout {
         ];
         return (
             dialogTypes.includes(metaWindow.window_type) ||
-            !metaWindow.resizeable
+            !metaWindow.resizeable ||
+            Meta.is_wayland_compositor() && metaWindow.get_transient_for() != null
         );
     }
 };


### PR DESCRIPTION
This PR contains two important patches.

First, on Wayalnd dialog windows not always get proper window type. It causes problems with Open dialogs for example or with tool windows of Android Studio. The only workaround that I found - check if the window has `transient` window.

Second, on Wayland window might be not set up properly until the first frame is rendered. It leads to glitches with dialog windows positioning (not in the center of the screen) and sizing (full screen instead of real size). As a fix, the extension should wait for the first frame before adding a window to list windows.