### PR TITLE
Add task bar item drag and drop across monitors

### DIFF
--- a/widget/workspaceList.js
+++ b/widget/workspaceList.js
@@ -26,7 +26,7 @@ var WorkspaceList = GObject.registerClass(
             this.connect('destroy', this._onDestroy.bind(this));
 
             this.add_child(this.buttonList);
-            this.dropPlaceholder = new DropPlaceholder();
+            this.dropPlaceholder = new DropPlaceholder(WorkspaceButton);
             this.dropPlaceholder.connect('drag-dropped', () => {
                 this.tempDragData.workspaceButton.reparent(this.buttonList);
             });
@@ -254,7 +254,7 @@ var WorkspaceButton = GObject.registerClass(
             }
         }
     },
-    class WorkspaceButton extends MatButton {
+    class InnerWorkspaceButton extends MatButton {
         _init(superWorkspaceManager, categoryKey, category) {
             let icon = new St.Icon({
                 gicon: category.icon,
@@ -352,20 +352,24 @@ var WorkspaceButton = GObject.registerClass(
                 manualMode: true
             });
 
-            this._draggable.connect('drag-end', (_, time, success, test) => {
+            this._draggable.connect('drag-end', () => {
                 this.mouseData.pressed = false;
                 this.mouseData.dragged = false;
             });
         }
 
-        handleDragOver(source, actor, x, y, time) {
-            //return this._workspace.handleDragOver(source, actor, x, y, time);
+        handleDragOver(source, actor, x, y) {
+            if (!(source instanceof WorkspaceButton)) {
+                return DND.DragMotionResult.NO_DROP;
+            }
             this.emit('drag-over', y < this.height / 2);
             return DND.DragMotionResult.MOVE_DROP;
         }
 
-        acceptDrop(source, actor, x, y, time) {
-            //this._workspace.acceptDrop(source, actor, x, y, time);
+        acceptDrop(source) {
+            if (!(source instanceof WorkspaceButton)) {
+                return false;
+            }
             this.emit('drag-dropped');
             return true;
         }

--- a/widget/workspaceList.js
+++ b/widget/workspaceList.js
@@ -23,6 +23,8 @@ var WorkspaceList = GObject.registerClass(
                 vertical: true
             });
 
+            this.connect('destroy', this._onDestroy.bind(this));
+
             this.add_child(this.buttonList);
             this.dropPlaceholder = new DropPlaceholder();
             this.dropPlaceholder.connect('drag-dropped', () => {
@@ -237,7 +239,7 @@ var WorkspaceList = GObject.registerClass(
             });
         }
 
-        on_destroy() {
+        _onDestroy() {
             global.workspace_manager.disconnect(this.workspaceSignal);
         }
     }


### PR DESCRIPTION
This PR allows items from task bar to be moved across screens in order to move windows from one screen to another.
It also fixes a bug when drag and dropping item from task bar to workspace list and vice versa.
Finally it contains some code style improvements.

