### PR TITLE
Allow task items to be dropped on an empty task bar

### DIFF
--- a/widget/taskBar.js
+++ b/widget/taskBar.js
@@ -316,6 +316,7 @@ let TaskBarItem = GObject.registerClass(
             this.window = window;
             this.app = app;
 
+            this.connect('destroy', this.destroy.bind(this));
             // ICON
             this.iconSize = 24;
             this.icon = app.create_icon_texture(this.iconSize);

--- a/widget/topPanelWidget.js
+++ b/widget/topPanelWidget.js
@@ -1,7 +1,5 @@
 const { GObject, St, Clutter, Gio } = imports.gi;
 
-const Main = imports.ui.main;
-
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const { MatButton } = Me.imports.widget.material.button;
@@ -15,6 +13,7 @@ var TopPanel = GObject.registerClass(
             super._init({
                 name: 'topPanel'
             });
+            this._delegate = this;
             this.superWorkspace = superWorkspace;
             this._leftContainer = new St.BoxLayout();
 
@@ -55,11 +54,20 @@ var TopPanel = GObject.registerClass(
             });
 
             this.tilingButton.connect('clicked', (actor, button) => {
-                // Go in reverse direction on right click (button: 3)
+                // Go in reverse direction on right click (button: 3)
                 superWorkspace.nextTiling(button === 3 ? -1 : 1);
             });
 
             this.add_child(this.tilingButton);
+        }
+
+        handleDragOver() {
+            return this.taskBar.updateCurrentTaskBar();
+        }
+
+        acceptDrop() {
+            this.taskBar.reparentDragItem();
+            return true;
         }
 
         vfunc_allocate(box, flags) {


### PR DESCRIPTION
This is a fix for #107, this allows to drag and drop task items between screens even if a screen has no tasks.