### PR TITLE
Hide panel in noUImode

### DIFF
--- a/module/hotKeysModule.js
+++ b/module/hotKeysModule.js
@@ -203,7 +203,7 @@ var HotKeysModule = class HotKeysModule {
             Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
             Shell.ActionMode.NORMAL,
             () => {
-                let noUImode = global.superWorkspaceManager.noUImode;
+                const noUImode = global.superWorkspaceManager.noUImode;
                 global.superWorkspaceManager.noUImode = !noUImode;
                 Main.panel.get_parent().visible = noUImode;
                 Main.panel.visible = noUImode;

--- a/module/hotKeysModule.js
+++ b/module/hotKeysModule.js
@@ -203,16 +203,16 @@ var HotKeysModule = class HotKeysModule {
             Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
             Shell.ActionMode.NORMAL,
             () => {
-                let noUImode = !global.superWorkspaceManager.noUImode;
-                global.superWorkspaceManager.noUImode = noUImode;
-                Main.panel.get_parent().visible = !noUImode;
-                Main.panel.visible = !noUImode;
+                let noUImode = global.superWorkspaceManager.noUImode;
+                global.superWorkspaceManager.noUImode = !noUImode;
+                Main.panel.get_parent().visible = noUImode;
+                Main.panel.visible = noUImode;
                 Main.panel
-                    .get_parent()
-                    .set_width(noUImode ? 0 : -1);
-                Main.layoutManager.panelBox.visible = !noUImode;
-
-                Main.layoutManager.panelBox.set_height(noUImode ? 0 : -1);
+                .get_parent()
+                .set_width(!noUImode ? 0 : -1);
+                Main.layoutManager.panelBox.visible = noUImode;
+                
+                Main.layoutManager.panelBox.set_height(!noUImode ? 0 : -1);
                 Main.layoutManager.monitors.forEach(monitor => {
                     let superWorkspace;
                     if (Main.layoutManager.primaryIndex === monitor.index) {
@@ -220,12 +220,12 @@ var HotKeysModule = class HotKeysModule {
                     } else {
                         superWorkspace = global.superWorkspaceManager.getSuperWorkspacesOfMonitorIndex(
                             monitor.index
-                        )[0];
-                    }
-                    Main.layoutManager._queueUpdateRegions();
-                    superWorkspace.updateUI();
-                    superWorkspace.panel.set_height(noUImode ? 0 : -1);
-                    superWorkspace.tilingLayout.onTile();
+                            )[0];
+                        }
+                        Main.layoutManager._queueUpdateRegions();
+                        superWorkspace.updateUI();
+                        superWorkspace.panel.set_height(!noUImode ? 0 : -1);
+                        superWorkspace.tilingLayout.onTile();
                 });
             }
         );

--- a/module/hotKeysModule.js
+++ b/module/hotKeysModule.js
@@ -203,19 +203,16 @@ var HotKeysModule = class HotKeysModule {
             Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
             Shell.ActionMode.NORMAL,
             () => {
-                global.superWorkspaceManager.noUImode = !global
-                    .superWorkspaceManager.noUImode;
-                Main.panel.get_parent().visible = !global.superWorkspaceManager
-                    .noUImode;
+                let noUImode = !global.superWorkspaceManager.noUImode;
+                global.superWorkspaceManager.noUImode = noUImode;
+                Main.panel.get_parent().visible = !noUImode;
+                Main.panel.visible = !noUImode;
                 Main.panel
                     .get_parent()
-                    .set_width(global.superWorkspaceManager.noUImode ? 0 : -1);
-                Main.layoutManager.panelBox.visible = !global
-                    .superWorkspaceManager.noUImode;
+                    .set_width(noUImode ? 0 : -1);
+                Main.layoutManager.panelBox.visible = !noUImode;
 
-                Main.layoutManager.panelBox.set_height(
-                    global.superWorkspaceManager.noUImode ? 0 : -1
-                );
+                Main.layoutManager.panelBox.set_height(noUImode ? 0 : -1);
                 Main.layoutManager.monitors.forEach(monitor => {
                     let superWorkspace;
                     if (Main.layoutManager.primaryIndex === monitor.index) {
@@ -227,9 +224,7 @@ var HotKeysModule = class HotKeysModule {
                     }
                     Main.layoutManager._queueUpdateRegions();
                     superWorkspace.updateUI();
-                    superWorkspace.panel.set_height(
-                        global.superWorkspaceManager.noUImode ? 0 : -1
-                    );
+                    superWorkspace.panel.set_height(noUImode ? 0 : -1);
                     superWorkspace.tilingLayout.onTile();
                 });
             }


### PR DESCRIPTION
fixes #93 

The main change is `Main.panel.visible = !noUImode`.
The other changes are simply storing the value in a temporary variable instead of fetching from globals, which makes it less cluttered.